### PR TITLE
[oauth2] Support url-encoded requests for oauth

### DIFF
--- a/deux/oauth2/backends.py
+++ b/deux/oauth2/backends.py
@@ -49,7 +49,7 @@ class MFARequestBackend(OAuthLibCore):
     def create_token_response(self, request):
         """
         Overrides the base method to pass in the request body instead of the
-        request because Djange only allows the request data stream to be read
+        request because Django only allows the request data stream to be read
         once.
 
         :param request: The request to create a token response from.

--- a/deux/oauth2/backends.py
+++ b/deux/oauth2/backends.py
@@ -7,9 +7,9 @@ from rest_framework.request import Request as DRFRequest
 from rest_framework.views import APIView
 
 if sys.version_info < (3,):
-    from urlparse import parse_qs as parse_url_body
+    from urlparse import parse_qs
 else:
-    from urllib import parse as parse_url_body
+    from urllib.parse import parse_qs
 
 
 class MFARequestBackend(OAuthLibCore):
@@ -40,8 +40,7 @@ class MFARequestBackend(OAuthLibCore):
         :param body: The request body in url encoded form.
         :returns: Dictionary with ``mfa_code`` and ``backup_code``.
         """
-        print parse_url_body(body)
-        params = {key: value[0] for key, value in parse_url_body(body).items()}
+        params = {key: value[0] for key, value in parse_qs(body).items()}
         return {
             "mfa_code": params.get("mfa_code"),
             "backup_code": params.get("backup_code"),

--- a/deux/oauth2/backends.py
+++ b/deux/oauth2/backends.py
@@ -1,11 +1,18 @@
 from __future__ import absolute_import, unicode_literals
 
-import json
+import sys
+from oauth2_provider.oauth2_backends import OAuthLibCore
 
-from oauth2_provider.oauth2_backends import JSONOAuthLibCore
+from rest_framework.request import Request as DRFRequest
+from rest_framework.views import APIView
+
+if sys.version_info < (3,):
+    from urlparse import parse_qs as parse_url_body
+else:
+    from urllib import parse as parse_url_body
 
 
-class MFARequestBackend(JSONOAuthLibCore):
+class MFARequestBackend(OAuthLibCore):
     """
     class::MFARequestBackend()
 
@@ -13,15 +20,46 @@ class MFARequestBackend(JSONOAuthLibCore):
     extra credentials (``mfa_code`` and ``backup_code``) from the request body.
     """
 
-    def _get_extra_credentials(self, request):
+    def extract_body(self, request):
         """
-        Gets dictionary of ``mfa_code`` and ``backup_code`` from the request.
+        Extract request body by coercing the request to a Django Rest
+        Framework Request.
 
-        :param request: The API request to this MFA backend class.
+        :params request: The request to extract the body from.
+        :returns: Returns the items in the requests body.
+        """
+        if not isinstance(request, DRFRequest):
+            request = APIView().initialize_request(request)
+        # our custom authorization view is already using DRF
+        return request.data.items() if request.data else []
+
+    def _get_extra_credentials(self, body):
+        """
+        Gets dictionary of ``mfa_code`` and ``backup_code`` from the body.
+
+        :param body: The request body in url encoded form.
         :returns: Dictionary with ``mfa_code`` and ``backup_code``.
         """
-        body = json.loads(request.body.decode("utf-8"))
+        print parse_url_body(body)
+        params = {key: value[0] for key, value in parse_url_body(body).items()}
         return {
-            "mfa_code": body.get("mfa_code"),
-            "backup_code": body.get("backup_code"),
+            "mfa_code": params.get("mfa_code"),
+            "backup_code": params.get("backup_code"),
         }
+
+    def create_token_response(self, request):
+        """
+        Overrides the base method to pass in the request body instead of the
+        request because Djange only allows the request data stream to be read
+        once.
+
+        :param request: The request to create a token response from.
+        :returns: The redirect uri, headers, body, and status of the response.
+        """
+        uri, http_method, body, headers = self._extract_params(request)
+        extra_credentials = self._get_extra_credentials(body)
+
+        headers, body, status = self.server.create_token_response(
+            uri, http_method, body, headers, extra_credentials)
+        uri = headers.get("Location", None)
+        return uri, headers, body, status

--- a/deux/oauth2/tests/test_authentication.py
+++ b/deux/oauth2/tests/test_authentication.py
@@ -5,6 +5,7 @@ import six
 from base64 import b64encode
 from mock import patch
 from oauth2_provider.models import get_application_model
+from urllib import urlencode
 
 from django.core.urlresolvers import reverse
 from rest_framework import status
@@ -121,6 +122,20 @@ class MFAOAuth2TokenTests(BaseUserTestCase):
             "Login does not take both a verification and backup code."
         )
 
+    def test_login_success_with_multipart(self):
+        data = self._get_data(backup_code=self.backup_code)
+        response = self.check_post_response(
+            self.url, status.HTTP_200_OK, data=data, headers=self.headers,
+            format="multipart")
+        self._assert_authenticated(response)
+
+    def test_login_success_with_urlencoded(self):
+        data = self._get_data(backup_code=self.backup_code)
+        response = self.check_post_response_with_url_encoded(
+            self.url, status.HTTP_200_OK, data=urlencode(data),
+            headers=self.headers)
+        self._assert_authenticated(response)
+
     def _assert_authenticated(self, response):
         content = json.loads(response.content.decode("utf-8"))
         self.assertIsNotNone(content.get("access_token"))
@@ -133,13 +148,16 @@ class MFAOAuth2TokenTests(BaseUserTestCase):
     def _get_data(
             self, username=None, password=None, mfa_code=None,
             backup_code=None):
-        return {
+        data = {
             "grant_type": "password",
             "username": username or self.user2.username,
             "password": password or self.password2,
-            "mfa_code": mfa_code,
-            "backup_code": backup_code
         }
+        if mfa_code:
+            data["mfa_code"] = mfa_code
+        if backup_code:
+            data["backup_code"] = backup_code
+        return data
 
     def _get_basic_auth_header(self, client_id, client_secret):
         """

--- a/deux/oauth2/tests/test_authentication.py
+++ b/deux/oauth2/tests/test_authentication.py
@@ -2,10 +2,10 @@ from __future__ import absolute_import, unicode_literals
 
 import json
 import six
+import sys
 from base64 import b64encode
 from mock import patch
 from oauth2_provider.models import get_application_model
-from urllib import urlencode
 
 from django.core.urlresolvers import reverse
 from rest_framework import status
@@ -14,6 +14,11 @@ from deux.app_settings import mfa_settings
 from deux.constants import SMS
 from deux.services import generate_mfa_code
 from deux.tests.test_base import BaseUserTestCase
+
+if sys.version_info < (3,):
+    from urllib import urlencode
+else:
+    from urllib.parse import urlencode
 
 Application = get_application_model()
 

--- a/deux/tests/test_base.py
+++ b/deux/tests/test_base.py
@@ -39,6 +39,17 @@ class BaseUserTestCase(APITestCase):
         self.assertEqual(response.status_code, expected_status_code)
         return response
 
+    def check_post_response_with_url_encoded(
+            self, url, expected_status_code, data=None, user=None,
+            headers=None):
+        headers = headers or {}
+        self.client.force_authenticate(user)
+        response = self.client.post(
+            url, data=data, content_type='application/x-www-form-urlencoded',
+            **headers)
+        self.assertEqual(response.status_code, expected_status_code)
+        return response
+
     def check_put_response(
             self, url, expected_status_code, data=None, user=None,
             format="json"):


### PR DESCRIPTION
Support url-encoded requests for OAuth by extracting body to a django rest framework. Tested by making url_encoded requests as well as a multipart request.