### PR TITLE
Updates import for TwilioRestClient and TwilioRestException to use 6.x twilio python sdk

### DIFF
--- a/deux/notifications.py
+++ b/deux/notifications.py
@@ -1,7 +1,16 @@
 from __future__ import absolute_import, unicode_literals
 
-from twilio.rest import TwilioRestClient
-from twilio.rest.exceptions import TwilioRestException
+try:
+    from twilio.rest import Client as TwilioRestClient
+except ImportError:
+    from twilio.rest import TwilioRestClient
+    print("DeprecationWarning: Importing TwilioRestClient from twilio.rest is deprecated. Update twilio package to >6.x")
+
+try:
+    from twilio.base.exceptions import TwilioRestException
+except ImportError:
+    from twilio.rest.exceptions import TwilioRestException
+    print("DeprecationWarning: Importing TwilioRestException from twilio.rest is deprecated. Update twilio package to >6.x")
 
 from deux import strings
 from deux.app_settings import mfa_settings

--- a/deux/tests/test_notifications.py
+++ b/deux/tests/test_notifications.py
@@ -1,7 +1,12 @@
 from __future__ import absolute_import, unicode_literals
 
 from mock import Mock, patch
-from twilio.rest.exceptions import TwilioRestException
+
+try:
+    from twilio.base.exceptions import TwilioRestException
+except ImportError: 
+    from twilio.rest.exceptions import TwilioRestException
+    print("DeprecationWarning: Importing TwilioRestException from twilio.rest is deprecated. Update twilio package to >6.x")
 
 from deux.app_settings import mfa_settings
 from deux.exceptions import InvalidPhoneNumberError, TwilioMessageError


### PR DESCRIPTION
Updates import for TwilioRestClient and TwilioRestException to use 6.x twilio python sdk