### PR TITLE
Add on_delete parameter to support Django 2.0

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
 Abhishek Fatehpuria <abhishek@robinhood.com>
+Max Burstein <https://maxburstein.com>

--- a/deux/abstract_models.py
+++ b/deux/abstract_models.py
@@ -28,8 +28,9 @@ class AbstractMultiFactorAuth(models.Model):
 
     #: User this MFA object represents.
     user = models.OneToOneField(
-        settings.AUTH_USER_MODEL, related_name="multi_factor_auth",
-        primary_key=True)
+        settings.AUTH_USER_MODEL, on_delete=models.CASCADE,
+        related_name="multi_factor_auth", primary_key=True
+    )
 
     #: User's phone number.
     phone_number = models.CharField(


### PR DESCRIPTION
From the release notes https://docs.djangoproject.com/en/2.0/releases/2.0/

> The on_delete argument for ForeignKey and OneToOneField is now required in models and migrations. Consider squashing migrations so that you have fewer of them to update.