### PR TITLE
Updating import paths for twilio package >6.x

### DIFF
--- a/deux/notifications.py
+++ b/deux/notifications.py
@@ -1,7 +1,18 @@
 from __future__ import absolute_import, unicode_literals
 
-from twilio.rest import TwilioRestClient
-from twilio.rest.exceptions import TwilioRestException
+try:
+    from twilio.rest import Client as TwilioRestClient
+except ImportError:
+    from twilio.rest import TwilioRestClient
+    print("DeprecationWarning: Importing TwilioRestClient from twilio.rest"
+          " is deprecated. Update twilio package to >6.x")
+
+try:
+    from twilio.base.exceptions import TwilioRestException
+except ImportError:
+    from twilio.rest.exceptions import TwilioRestException
+    print("DeprecationWarning: Importing TwilioRestException from twilio.rest"
+          " is deprecated. Update twilio package to >6.x")
 
 from deux import strings
 from deux.app_settings import mfa_settings

--- a/deux/validators.py
+++ b/deux/validators.py
@@ -6,5 +6,5 @@ from deux import strings
 
 #: Regex validator for phone numbers.
 phone_number_validator = RegexValidator(
-    regex=r"^(\d{7,15})$",
+    regex=r"^\+[1-9]\d{1,14}$",
     message=strings.INVALID_PHONE_NUMBER_ERROR)


### PR DESCRIPTION
Twilio package >6.x has changed the locations for TwilioRestClient & TwilioRestException.  

This pull request wraps the new import paths in a "try", which falls back to the old import paths if a Twilio package under version 6 is installed.