### PR TITLE
fixed twilio exception import

### DIFF
--- a/deux/notifications.py
+++ b/deux/notifications.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from twilio.rest import TwilioRestClient
-from twilio.rest.exceptions import TwilioRestException
+from twilio.base.exceptions import TwilioRestException
 
 from deux import strings
 from deux.app_settings import mfa_settings


### PR DESCRIPTION
The Twilio exception class was moved in the latest version of their Python package.

https://github.com/twilio/twilio-python/blob/2d87f002d78d5c177eed8e0b8a8226fe2a5c2e1a/README.md#handling-exceptions

> ```from twilio.base.exceptions import TwilioRestException```

Without it you get an import error:

```
 File "/home/nick/.local/share/virtualenvs/app-4PlAip0Q/lib/python3.6/site-packages/deux/notifications.py", line 4, in <module>
    from twilio.rest.exceptions import TwilioRestException
ModuleNotFoundError: No module named 'twilio.rest.exceptions'
```